### PR TITLE
Remove unused variable

### DIFF
--- a/group_lectures/02_search/02_gradient.py
+++ b/group_lectures/02_search/02_gradient.py
@@ -28,8 +28,6 @@ def plot_gradient_ascent(function,derivative,start,stop,steps):
     fig = plt.figure("INF3490 - Gradient Ascent")
     fig.suptitle("Visualization of gradient ascent")
 
-    step = (stop - start) / steps
-
     plt.subplot(211)
     plt.plot(x,function(x))
     randx = random.uniform(start,stop)


### PR DESCRIPTION
The `step` variable isn't used. Perhaps it was meant to be used as an addition to the `abs(dx) > precision` clause?