### PR TITLE
Add python-tk as a dependency

### DIFF
--- a/group_lectures/00_setup/README.md
+++ b/group_lectures/00_setup/README.md
@@ -29,8 +29,8 @@ $ brew install python3
 
 ### Ubuntu(Server) install
 ```
-$ sudo apt-get install python
-$ sudo apt-get install python3
+$ sudo apt-get install python python-tk
+$ sudo apt-get install python3 python3-tk
 ```
 
 ### Windows install


### PR DESCRIPTION
Python2 without the package:

```
Traceback (most recent call last):
  File "02_gradient.py", line 6, in <module>
    import matplotlib.pyplot as plt
  File "/home/km/.local/lib/python2.7/site-packages/matplotlib/pyplot.py", line 115, in <module>
    _backend_mod, new_figure_manager, draw_if_interactive, _show = pylab_setup()
  File "/home/km/.local/lib/python2.7/site-packages/matplotlib/backends/__init__.py", line 32, in pylab_setup
    globals(),locals(),[backend_name],0)
  File "/home/km/.local/lib/python2.7/site-packages/matplotlib/backends/backend_tkagg.py", line 6, in <module>
    from six.moves import tkinter as Tk
  File "/home/km/.local/lib/python2.7/site-packages/six.py", line 203, in load_module
    mod = mod._resolve()
  File "/home/km/.local/lib/python2.7/site-packages/six.py", line 115, in _resolve
    return _import_module(self.mod)
  File "/home/km/.local/lib/python2.7/site-packages/six.py", line 82, in _import_module
    __import__(name)
  File "/usr/lib/python2.7/lib-tk/Tkinter.py", line 42, in <module>
    raise ImportError, str(msg) + ', please install the python-tk package'
ImportError: No module named _tkinter, please install the python-tk package
```

Python3 without the package:

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/tkinter/__init__.py", line 36, in <module>
    import _tkinter
ImportError: No module named '_tkinter'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "02_gradient.py", line 6, in <module>
    import matplotlib.pyplot as plt
  File "/home/km/.local/lib/python3.5/site-packages/matplotlib/pyplot.py", line 115, in <module>
    _backend_mod, new_figure_manager, draw_if_interactive, _show = pylab_setup()
  File "/home/km/.local/lib/python3.5/site-packages/matplotlib/backends/__init__.py", line 32, in pylab_setup
    globals(),locals(),[backend_name],0)
  File "/home/km/.local/lib/python3.5/site-packages/matplotlib/backends/backend_tkagg.py", line 6, in <module>
    from six.moves import tkinter as Tk
  File "/home/km/.local/lib/python3.5/site-packages/six.py", line 92, in __get__
    result = self._resolve()
  File "/home/km/.local/lib/python3.5/site-packages/six.py", line 115, in _resolve
    return _import_module(self.mod)
  File "/home/km/.local/lib/python3.5/site-packages/six.py", line 82, in _import_module
    __import__(name)
  File "/usr/lib/python3.5/tkinter/__init__.py", line 38, in <module>
    raise ImportError(str(msg) + ', please install the python3-tk package')
ImportError: No module named '_tkinter', please install the python3-tk package
```